### PR TITLE
Update timm model name

### DIFF
--- a/omnidata_tools/torch/modules/midas/vit.py
+++ b/omnidata_tools/torch/modules/midas/vit.py
@@ -480,7 +480,7 @@ def _make_vit_b_rn50_backbone(
 def _make_pretrained_vitb_rn50_384(
     pretrained, use_readout="ignore", hooks=None, use_vit_only=False
 ):
-    model = timm.create_model("vit_base_resnet50_384", pretrained=pretrained)
+    model = timm.create_model("vit_base_r50_s16_384", pretrained=pretrained)
 
     hooks = [0, 1, 8, 11] if hooks == None else hooks
     return _make_vit_b_rn50_backbone(


### PR DESCRIPTION
`vit_base_resnet50_384` was a deprecated (now-removed) alias for `vit_base_r50_s16_384` (see [[here](https://github.com/rwightman/pytorch-image-models/blob/7096b52a613eefb4f6d8107366611c8983478b19/timm/models/vision_transformer_hybrid.py#L244)]). This PR makes `omnidata-tools` compatible with recent versions of `timm` and does not affect compatibility with the `timm` version listed in the existing `requirements.txt`.